### PR TITLE
Feature/docker improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,3 @@
 node_modules
+dist
+public/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:6.9.5
+ENV TZ="/usr/share/zoneinfo/Europe/Vienna"
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+export FOOD_PORT ?= 3000
+
+start:
+	docker-compose up --build
+
+start-daemon:
+	docker-compose up --build -d
+
+restart:
+	docker-compose restart
+
+stop:
+	docker-compose stop
+
+npm-build:
+	docker-compose exec node npm run build
+
+ssh-node:
+	docker-compose exec node sh
+
+ssh-redis:
+	docker-compose exec redis sh

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,5 @@ ssh-node:
 
 ssh-redis:
 	docker-compose exec redis sh
+
+trigger-rebuild: stop start-daemon

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,20 @@ services:
 
   node:
     build: .
+    volumes: # these are all folders where updates to the code get sync'ed into the docker container
+     - ./caching:/usr/src/app/caching
+     - ./externals:/usr/src/app/externals
+     - ./helpers:/usr/src/app/helpers
+     - ./middleware:/usr/src/app/middleware
+     - ./models:/usr/src/app/models
+     - ./public/styles:/usr/src/app/public/styles
+     - ./routes:/usr/src/app/routes
+     - ./scraping:/usr/src/app/scraping
+     - ./test:/usr/src/app/test
+     - ./views:/usr/src/app/views
     ports:
      - "${FOOD_PORT}:3000"
+    depends_on:
+     - redis
     links:
      - redis


### PR DESCRIPTION
makefile targets:

- `start`, `start-daemon`: starts containers either in foreground or background
- `restart`: restarts the running containers
- `stop`: stops running containers
- `npm-build`: runs `npm run build` in the (running) node container
- `ssh-node`: get a shell for the node-container
- `ssh-redis`: get a shell for the redis-container

if `FOOD_PORT` is not set, then it is set to 3000 by default. Otherwise, start the containers with `FOOD_PORT=4444 make start` etc.