### PR TITLE
autorestart aaufood-container after server restart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
 
   node:
     build: .
+    restart: always
     volumes: # these are all folders where updates to the code get sync'ed into the docker container
      - ./caching:/usr/src/app/caching
      - ./externals:/usr/src/app/externals


### PR DESCRIPTION
Dieser branch sollte an und für sich das leidige Problem mit der nicht-Erreichbarkeit von AAUFood am Montagmorgen lösen.

(Vielleicht aber auch nicht. 😄)