### PR TITLE
Fix for Mensa Scraper in holidays

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
      - ./scraping:/usr/src/app/scraping
      - ./test:/usr/src/app/test
      - ./views:/usr/src/app/views
+     - ./config.js:/usr/src/app/config.js
     ports:
      - "${FOOD_PORT}:3000"
     depends_on:

--- a/scraping/scraper.js
+++ b/scraping/scraper.js
@@ -169,7 +169,9 @@ function parseMensa(html) {
             menu.mains.push(classic2Food);
 
             let AAUSpecialFood = createFoodFromMensaAAUSpecialCategory(AAUSpecialCategory, dayInWeek);
-            menu.mains.push(AAUSpecialFood);
+            if (AAUSpecialFood != null){
+                menu.mains.push(AAUSpecialFood);
+            }
         } catch (ex) {
             //Do not log error, as it is most likely to be a parsing error, which we do not want to fill the log file
             menu.error = true;
@@ -230,7 +232,12 @@ function createFoodFromMensaAAUSpecialCategory(category, currentDay) {
     let currentDayName = dayNames[currentDay];
     let categoryContent = category.find(".category-content");
 
-    let meal = categoryContent.find(`p:contains(${currentDayName})`).text().split(":")[1].trim();
+    let meal = categoryContent.find(`p:contains(${currentDayName})`).text();
+    if (meal.length === 0){
+        return null;
+    } else {
+        meal = meal.split(":")[1].trim();
+    }
     let foodNames = [meal];
 
     //Price


### PR DESCRIPTION
During holidays the Mensa scraper would not work, as there's no AAU-Teller in such cases.
Also, i think config.js shoudl be synced with Docker containers.