### PR TITLE
Mittagstisch heißt jetzt Hotspot

### DIFF
--- a/views/partials/day.ejs
+++ b/views/partials/day.ejs
@@ -15,7 +15,7 @@
             <%- include('restaurant', {restaurant: 'uniwirt', restaurantName: 'Uniwirt', menu: uniwirt ? uniwirt[day] : null}) %>
         </div>
         <div class="col-xl-3 col-lg-6 col-md-12">
-            <%- include('restaurant', {restaurant: 'mittagstisch', restaurantName: 'Mittagstisch', menu: mittagstisch ? mittagstisch[day] : null}) %>
+            <%- include('restaurant', {restaurant: 'mittagstisch', restaurantName: 'Hotspot', menu: mittagstisch ? mittagstisch[day] : null}) %>
         </div>
         <div class="col-xl-3 col-lg-6 col-md-12">
             <%- include('restaurant', {restaurant: 'uni-pizzeria', restaurantName: 'Uni-Pizzeria', menu: uniPizzeria ? uniPizzeria[day] : null}) %>


### PR DESCRIPTION
Es ist zu entscheiden, wie tiefgreifend "Mittagstisch" bei uns durch "Hotspot" ersetzt werden soll.

In der ersten Variante (weil ich faul bin und im Bus sitze): nur `restaurantName` ausgetauscht.