### PR TITLE
Fixed scraping for new Mensa page + Hotspot

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -20,7 +20,7 @@ module.exports = {
         dailyVisitorKey: "dailyVisitors"
     },
     scraper: {
-        mensaUrl: "http://menu.mensen.at/index/index/locid/45",
+        mensaUrl: "https://menu.mensen.at/index/index/locid/45",
         uniwirtUrl: "http://www.uniwirt.at",
         hotspotUrl: "https://www.lakeside-scitec.com/services/gastronomie/hotspot",
         unipizzeriaUrl: "http://www.uni-pizzeria.at/speisen/mittagsteller.html",

--- a/app/models/food.js
+++ b/app/models/food.js
@@ -1,12 +1,18 @@
 "use strict";
 
 const allergenRegex = /(\(?\s*(\s*.\s*,|.\s*,\s*.)+,?\s*\)?)\s*$/i;
+const fullCapsAllergenRegex = /([A-Z]+)$/;
 
 class Food {
     constructor(name, price, isInfo) {
         this.name = name;
-        if (price != null && !isNaN(price))
-            this.price = price;
+        if (price != null) {
+            if (typeof price === 'number' && !isNaN(price)){
+                this.price = price;
+            } else if(typeof price === "string") {
+                this.price = price.replace(/ +€?$/, ""); // trim leading spaces and € signs
+            }
+        } 
         this.isInfo = isInfo === true;
 
         this.extractAllergens();
@@ -17,14 +23,22 @@ class Food {
 
         if (this.isInfo || !this.name)
             return;
-        
-        var allergenMatch = allergenRegex.exec(this.name);
-        if (allergenMatch == null)
-            return;
 
-        // Cleanup allergens: Remove all irrelevant chars, uppercase them, separate them by ','
-        this.allergens = allergenMatch[0].replace(/[^A-Za-z]/ig, "").toUpperCase().replace(/(.)(?=.)/g, '$1,');
-        this.name = this.name.substring(0, allergenMatch.index).trim();
+        var allergenMatch = allergenRegex.exec(this.name);
+        if (allergenMatch != null) {
+            // Cleanup allergens: Remove all irrelevant chars, uppercase them, separate them by ','
+            this.allergens = allergenMatch[0].replace(/[^A-Za-z]/ig, "").toUpperCase().replace(/(.)(?=.)/g, '$1,');
+            this.name = this.name.substring(0, allergenMatch.index).trim();
+            return;
+        }
+
+        allergenMatch = fullCapsAllergenRegex.exec(this.name);
+        if (allergenMatch != null) {
+            // Separate allergens by ','
+            this.allergens = allergenMatch[0].split("").join(",");
+            this.name = this.name.substring(0, allergenMatch.index).trim();
+        }
+
     }
 }
 

--- a/app/models/food.js
+++ b/app/models/food.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const allergenRegex = /(\(?\s*(\s*.\s*,|.\s*,\s*.)+,?\s*\)?)\s*$/i;
+const allergenRegex = /(\(?\s*(\s*.\s*,|.\s*,\s*.)+,?\s*\)?|\(.\))\s*$/i;
 const fullCapsAllergenRegex = /([A-Z]+)$/;
 
 class Food {

--- a/app/public/styles/app.scss
+++ b/app/public/styles/app.scss
@@ -188,6 +188,15 @@ ul.info-elements{
 .cc_banner.cc_container.cc_container--open {
   background-color: $footerColor !important;
   border-bottom: 1pt solid black;
+
+  position: static;
+}
+
+#cookieConsentHolder {
+  position: absolute;
+  bottom: $footerHeight;
+  width: 100%;
+  left: 0;
 }
 
 footer {

--- a/app/scraping/scraper.js
+++ b/app/scraping/scraper.js
@@ -569,7 +569,7 @@ function parseBitsnBytes(html) {
         }
 
         let priceField = main.find("> td:contains(€)");
-        price = scraperHelper.parsePrice(priceField.text());
+        let price = scraperHelper.parsePrice(priceField.text());
 
         let mainCourse = new Food(title, parseFloat(price));
         mainCourse.entries = [new Food(description)];

--- a/app/scraping/scraperHelper.js
+++ b/app/scraping/scraperHelper.js
@@ -1,13 +1,13 @@
 "use strict";
 
-function _setErrorOnEmpty(menu) {
+function setErrorOnEmpty(menu) {
     if (!menu.closed && !menu.noMenu && (menu.starters.length + menu.mains.length + menu.alacarte.length === 0)) {
         menu.error = true;
     }
     return menu;
 }
 
-function _invalidateMenus (weekPlan) {
+function invalidateMenus (weekPlan) {
   for (let i = 0; i < 6; i++) {
       let outdatedMenu = new Menu();
       outdatedMenu.outdated = true;
@@ -16,7 +16,7 @@ function _invalidateMenus (weekPlan) {
   return weekPlan;
 }
 
-function _sanitizeName(val) {
+function sanitizeName(val) {
     if (typeof val === "string") {
         val = val.replace(/€?\s[0-9](,|.)[0-9]+/, ""); // Replace '€ 00.00'
         val = val.replace(/^[1-9].\s/, ""); // Replace '1. ', '2. '
@@ -33,7 +33,7 @@ function _sanitizeName(val) {
     }
 }
 
-function _decapitalize(string)
+function decapitalize(string)
 {
     const exceptionList = ["in", "an", "mit", "und"]; //words that should not be capitalized
     const seperators = [" ", "\"", "-"]; //seperators, make sure to keep "-" at end (different semantics)
@@ -55,7 +55,7 @@ function _decapitalize(string)
     return returnstring;
 }
 
-function _capitalizeFirstLetter(string, delim, exceptionList)
+function capitalizeFirstLetter(string, delim, exceptionList)
 {
     if (string !== "" && string !== null)
     {
@@ -68,7 +68,7 @@ function _capitalizeFirstLetter(string, delim, exceptionList)
 }
 
 const priceRegex = /(\d+[,\.]?\d*)/
-function _parsePrice(str) {
+function parsePrice(str) {
     if (!str){
         return null;
     }
@@ -80,11 +80,21 @@ function _parsePrice(str) {
         return null;
     }
 }
+
+function stripHtml(str){
+    if(!str){
+        return str;
+    }
+
+    return str.replace(/<\/?[^>]+(>|$)/g, "");
+}
+
 module.exports = {
-    setErrorOnEmpty: _setErrorOnEmpty,
-    invalidateMenus: _invalidateMenus,
-    sanitizeName: _sanitizeName,
-    capitalizeFirstLetter: _capitalizeFirstLetter,
-    decapitalize: _decapitalize,
-    parsePrice: _parsePrice,
+    setErrorOnEmpty,
+    invalidateMenus,
+    sanitizeName,
+    capitalizeFirstLetter,
+    decapitalize,
+    parsePrice,
+    stripHtml,
 };

--- a/app/scraping/scraperHelper.js
+++ b/app/scraping/scraperHelper.js
@@ -67,10 +67,24 @@ function _capitalizeFirstLetter(string, delim, exceptionList)
     }
 }
 
+const priceRegex = /(\d+[,\.]?\d*)/
+function _parsePrice(str) {
+    if (!str){
+        return null;
+    }
+
+    let match = priceRegex.exec(str);
+    if (match) {
+        return +match[0].replace(',', '.');
+    } else {
+        return null;
+    }
+}
 module.exports = {
     setErrorOnEmpty: _setErrorOnEmpty,
     invalidateMenus: _invalidateMenus,
     sanitizeName: _sanitizeName,
     capitalizeFirstLetter: _capitalizeFirstLetter,
-    decapitalize: _decapitalize
+    decapitalize: _decapitalize,
+    parsePrice: _parsePrice,
 };

--- a/app/views/partials/common/footer.ejs
+++ b/app/views/partials/common/footer.ejs
@@ -1,6 +1,6 @@
-<div id="cookieConsentHolder"></div>
-
 <footer id="footer" class="footer">
+    <div id="cookieConsentHolder"></div>
+
     <div class="daily-counter" title="Besucher heute">
         <i class="fa fa-fw fa-clock" aria-hidden="true"></i>
         <span id="dailyVisitors">

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "express-session": "^1.13.0",
     "extract-text-webpack-plugin": "^2.0.0-beta",
     "font-awesome": "^4.7.0",
+    "he": "^1.2.0",
     "jquery": "^3.2.1",
     "moment": "^2.17.1",
     "morgan": "^1.7.0",


### PR DESCRIPTION
This PR addresses these problems:

- Cookie consent banner does not overlap the footer anymore
- Rewrote Mensa scraping to fit new page.
- Fixed Hotspot scraper
   -  now correctly includes soups, parsed allergens and the missing first food. (#66 )
   - shows menus for non-today dates with "... des Tages" excluded (#64 )

Unfortunately it's all in a single PR. I implemented some new helper functions which I then used in both scrapers, so the commits where hard to split.

Screenshot for week 9.12.2019 - 13.12.2019
![image](https://user-images.githubusercontent.com/5564731/70572141-7e3e8d00-1b9f-11ea-97c4-d2a66aba3dec.png)
